### PR TITLE
It's better to display the candidate box using Its own GUI at the mouse position rather than using tooltip when there is no caret..

### DIFF
--- a/Lib/GetCaretPosEx/GetCaretPosEx.patch
+++ b/Lib/GetCaretPosEx/GetCaretPosEx.patch
@@ -1,7 +1,19 @@
 diff --git a/Lib/GetCaretPosEx/GetCaretPosEx.ahk b/Lib/GetCaretPosEx/GetCaretPosEx.ahk
-index ff9a7f7..b3ee558 100644
+index ff9a7f7..92f5109 100644
 --- a/Lib/GetCaretPosEx/GetCaretPosEx.ahk
 +++ b/Lib/GetCaretPosEx/GetCaretPosEx.ahk
+@@ -14,6 +14,11 @@ GetCaretPosEx(&left?, &top?, &right?, &bottom?, useHook := false) {
+         className := WinGetClass(hwnd)
+     catch
+         className := ""
++
++    ; adobe typing mode is not a normal input mode, exclude it
++    if className == "PSViewC" or className == "DroverLord - Window Class"
++        return false
++
+     if className ~= "^(?:Windows|Microsoft)\.UI\..+"
+         funcs := [getCaretPosFromUIA, getCaretPosFromHook, getCaretPosFromMSAA]
+     else if className ~= "^HwndWrapper\[PowerShell_ISE\.exe;;[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\]"
 @@ -332,8 +332,12 @@ end:
      }
  

--- a/Lib/RabbitCandidateBox.ahk
+++ b/Lib/RabbitCandidateBox.ahk
@@ -32,13 +32,15 @@ class CandidateBox extends Gui {
         this.Opt("-Caption +Owner AlwaysOnTop " . WS_EX_NOACTIVATE)
         this.MarginX := 3
         this.MarginY := 3
-        this.SetFont("S12", "Microsoft YaHei UI")
+        this.BackColor := 0x191919
+        this.SetFont("S12 cWhite", "Microsoft YaHei UI")
 
         this.pre := this.AddText(, "p")
         this.pre.GetPos(, , , &h)
         this.preedit_height := h
-        this.lv := this.AddListView("-Multi -Hdr -E0x200 LV0x10000", ["i", "c", "m"])
-        DllCall("uxtheme\SetWindowTheme", "ptr", this.lv.hwnd, "WStr", "Explorer", "Ptr", 0)
+        this.lv := this.AddListView("-Multi -Hdr -E0x200 LV0x10000 cWhite Background0x191919", ["i", "c", "m"])
+        DllCall("uxtheme\SetWindowTheme", "ptr", this.lv.hwnd, "WStr", "DarkMode_Explorer", "Ptr", 0)
+        DllCall("uxtheme\SetWindowTheme", "ptr", this.lv.hwnd, "WStr", "DarkMode_ItemsView", "ptr", 0)
 
         this.dummy_lv1 := this.AddListView("-Multi -Hdr -E0x200 LV0x40 Hidden R1", ["p"])
         this.dummy_lv2 := this.AddListView("-Multi -Hdr -E0x200 LV0x40 Hidden R2", ["p"])

--- a/Lib/RabbitMonitors.ahk
+++ b/Lib/RabbitMonitors.ahk
@@ -131,7 +131,7 @@ class MonitorInfoEx extends MonitorInfo {
     static struct_size := MonitorInfoEx.device_offset + A_WCharSize * CCHDEVICENAME
 
     device {
-        get => StrGet(this + MonitorInfoEx.device_offset, CCHDEVICENAME)
+        get => StrGet(this.Ptr + MonitorInfoEx.device_offset, CCHDEVICENAME)
     }
 } ; MonitorInfoEx
 

--- a/Rabbit.ahk
+++ b/Rabbit.ahk
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 - 2005 Xuesong Peng <pengxuesong.cn@gmail.com>
+ * Copyright (c) 2023 - 2025 Xuesong Peng <pengxuesong.cn@gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -352,7 +352,7 @@ ProcessKey(key, mask, this_hotkey) {
         else
             last_is_hide := false
         SendText(commit.text)
-        ToolTip()
+        ; ToolTip()
         box.Show("Hide")
         rime.free_commit(commit)
     } else
@@ -416,15 +416,21 @@ ProcessKey(key, mask, this_hotkey) {
                 prev_x := new_x
                 prev_y := new_y
             } else if !show_at_left_top {
-                has_selected := GetCompositionText(context.composition, &pre_selected, &selected, &post_selected)
-                preedit_text := pre_selected
-                if has_selected
-                    preedit_text := preedit_text . "[" . selected "]" . post_selected
-                ToolTip(preedit_text . "`r`n" . GetMenuText(context.menu))
+                ; has_selected := GetCompositionText(context.composition, &pre_selected, &selected, &post_selected)
+                ; preedit_text := pre_selected
+                ; if has_selected
+                ;     preedit_text := preedit_text . "[" . selected "]" . post_selected
+                ; ToolTip(preedit_text . "`r`n" . GetMenuText(context.menu))
+                backup_mouse_ref := A_CoordModeMouse
+                CoordMode("Mouse", "Screen")
+                MouseGetPos(&mouse_x, &mouse_y)
+                CoordMode("Mouse", backup_mouse_ref)
+                box.Build(context, &box_width, &box_height)
+                box.Show("AutoSize NA x" . mouse_x . " y" . mouse_y)
             }
             prev_show := true
         } else {
-            ToolTip()
+            ; ToolTip()
             box.Show("Hide")
             prev_show := false
         }


### PR DESCRIPTION
当没有光标显示时, 用`CandidateBox`在鼠标位置显示, 保持候选界面的一致
修复`RabbitMonitors.ahk`里的一个小错误